### PR TITLE
Fix KeyError 'title' when URLs contain playlist parameters

### DIFF
--- a/y2tmp3/downloader.py
+++ b/y2tmp3/downloader.py
@@ -37,6 +37,7 @@ def download_youtube_as_mp3(
         "quiet": True,
         "no_warnings": True,
         "extract_flat": False,
+        "noplaylist": True,  # Force single video extraction even if URL has playlist params
     }
 
     try:
@@ -72,6 +73,7 @@ def download_youtube_as_mp3(
                 "extract_flat": False,
                 "writethumbnail": False,
                 "writeinfojson": False,
+                "noplaylist": True,  # Force single video download even if URL has playlist params
             }
 
             # Download the file with rich progress bar

--- a/y2tmp3/playlist.py
+++ b/y2tmp3/playlist.py
@@ -46,8 +46,23 @@ class PlaylistDownloader:
                 info = ydl.extract_info(url, download=False)
                 
                 if "entries" not in info:
-                    # Single video, not a playlist
-                    return [info]
+                    # Single video, not a playlist - need to extract full info
+                    # Re-extract without flat mode to get title and other metadata
+                    ydl_opts_full = {
+                        "quiet": True,
+                        "no_warnings": True,
+                        "extract_flat": False,
+                        "noplaylist": True,  # Force single video extraction
+                    }
+                    with yt_dlp.YoutubeDL(ydl_opts_full) as ydl_full:
+                        full_info = ydl_full.extract_info(url, download=False)
+                        return [{
+                            "id": full_info.get("id", "unknown"),
+                            "title": full_info.get("title", "Unknown"),
+                            "url": url,
+                            "duration": full_info.get("duration"),
+                            "uploader": full_info.get("uploader", "Unknown"),
+                        }]
                 
                 # Filter out None entries and extract video info
                 videos = []


### PR DESCRIPTION
## Summary
- Fixes critical bug where URLs containing playlist parameters (e.g., `youtu.be/VIDEO_ID?list=PLAYLIST_ID`) would crash with `KeyError: 'title'`
- Ensures proper handling of mixed single-video/playlist URLs by forcing single video extraction when appropriate

## Test plan
- [x] Test with problematic URL: `https://youtu.be/Nfk1Su1Q8SI?list=RDNfk1Su1Q8SI`
- [x] Verify successful MP3 download and conversion
- [x] Confirm no regression in normal single video downloads
- [x] Verify playlist downloads still work correctly

🤖 Generated with [opencode](https://opencode.ai)